### PR TITLE
feat(merger/merge): add `batch_size` options to allow providing a max number of grouped jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Format: `Boolean`
 
 e.g. `true`
 
+### `batch_size` (optional, default: `nil`)
+
+Allow to specify how many jobs max to provide as arguments per aggregation
+
+Format: `Int`
+
+e.g. `50`
+
 ## Web UI
 
 ![Web UI](misc/web_ui.png)

--- a/lib/sidekiq-merger.rb
+++ b/lib/sidekiq-merger.rb
@@ -7,7 +7,7 @@ Sidekiq.configure_client do |config|
 end
 
 Sidekiq.configure_server do |config|
-  config.client_middleware do |chain|
+  config.server_middleware do |chain|
     chain.add Sidekiq::Merger::Middleware
   end
 end

--- a/lib/sidekiq-merger.rb
+++ b/lib/sidekiq-merger.rb
@@ -7,7 +7,7 @@ Sidekiq.configure_client do |config|
 end
 
 Sidekiq.configure_server do |config|
-  config.server_middleware do |chain|
+  config.client_middleware do |chain|
     chain.add Sidekiq::Merger::Middleware
   end
 end


### PR DESCRIPTION
### Feature proposal

We want to prevent having "merged jobs" instantiated with 1000 or more jobs aggregation.
This PR introduce a new options that allow to "split" created "merged jobs" by `batch_size` jobs.

### Usage 

```ruby
sidekiq_options queue: 'index',
                retry: false,
                merger: {
                    # we want to group jobs by tenant, index (args[0..1])
                    key: ->(args) { args[0..1].join('-') },
                    batch_size: 50 # batch max 50 jobs per 50 jobs
                }
```