### PR TITLE
remove ruby version upper bound, test against 2.5 - 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,39 +11,42 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: true
   EnforcedStyle: 'space'
 
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideReferenceBrackets:
   Enabled: true
 
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
 
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceInsideBlockBraces:
   Enabled: true
 
-Style/SpaceBeforeComma:
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
   Enabled: false
 
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: true
 
-Style/SpaceAfterComma:
+Layout/SpaceAfterComma:
   Enabled: true
 
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Enabled: true
   AllowForAlignment: true
 
 Lint/DuplicateMethods:
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: true
   Max: 200
   AllowHeredoc: true
@@ -67,16 +70,13 @@ Style/ClassAndModuleChildren:
   Exclude:
     - lib/sidekiq/merger/version.rb
 
-Rails/PluralizationGrammar:
+Layout/ArrayAlignment:
   Enabled: true
 
-Style/AlignArray:
+Layout/HashAlignment:
   Enabled: true
 
-Style/AlignHash:
-  Enabled: true
-
-Style/BlockEndNewline:
+Layout/BlockEndNewline:
   Enabled: false
 
 Style/DoubleNegation:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.5.9
+  - 2.6.7
+  - 2.7.3
 gemfile:
   - gemfiles/sidekiq_4_0.gemfile
   - gemfiles/sidekiq_4_1.gemfile

--- a/sidekiq-merger.gemspec
+++ b/sidekiq-merger.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = [">= 2.2.2", "< 2.6"]
+  spec.required_ruby_version = [">= 2.5.0"]
 
   spec.add_development_dependency "rake", ">= 10.0", "< 13"
   spec.add_development_dependency "rspec", ">= 3.0", "< 4"
   spec.add_development_dependency "simplecov", "~> 0.12"
   spec.add_development_dependency "timecop", "~> 0.8"
-  spec.add_development_dependency "rubocop", "~> 0.47"
+  spec.add_development_dependency "rubocop", "~> 0.93.1"
   spec.add_development_dependency "coveralls", "~> 0.8"
   spec.add_development_dependency "appraisal"
 


### PR DESCRIPTION
- Allows for use with Ruby 2.5+
- Tests in TravisCI against currently supported Ruby versions: 2.5.9, 2.6.7, 2.7.3
- update and pin rubocop and .rubocop.yml rules